### PR TITLE
Use double quotes for interpolated variable

### DIFF
--- a/includes/abstracts/class-charitable-query.php
+++ b/includes/abstracts/class-charitable-query.php
@@ -193,7 +193,7 @@ abstract class Charitable_Query implements Iterator {
      */
     public function orderby() {
         global $wpdb;
-        return apply_filters( 'charitable_query_orderby', 'ORDER BY {$wpdb->posts}.ID', $this );
+        return apply_filters( 'charitable_query_orderby', "ORDER BY {$wpdb->posts}.ID", $this );
     }
 
     /**


### PR DESCRIPTION
Otherwise the function must be overwritten or the `charitable_query_orderby` filter must be created in order to avoid invalid SQL syntax