### PR TITLE
Handle Unexpected Results in Registration Error Scenarios

### DIFF
--- a/includes/users/class-charitable-registration-form.php
+++ b/includes/users/class-charitable-registration-form.php
@@ -135,7 +135,7 @@ class Charitable_Registration_Form extends Charitable_Form {
 
         if ( isset( $submitted[ 'user_pass' ] ) ) {
             $creds = array();
-            $creds['user_login'] = isset( $submitted[ 'user_login' ] ) ? $submitted[ 'user_login' ] : $user->user_login; 
+            $creds['user_login'] = $user->user_login;
             $creds['user_password'] = $submitted[ 'user_pass' ];
             $creds['remember'] = true;
             $result = wp_signon( $creds, false );

--- a/includes/users/class-charitable-registration-form.php
+++ b/includes/users/class-charitable-registration-form.php
@@ -138,7 +138,12 @@ class Charitable_Registration_Form extends Charitable_Form {
             $creds['user_login'] = isset( $submitted[ 'user_login' ] ) ? $submitted[ 'user_login' ] : $user->user_login; 
             $creds['user_password'] = $submitted[ 'user_pass' ];
             $creds['remember'] = true;
-            wp_signon( $creds, false );
+            $result = wp_signon( $creds, false );
+
+            if ( is_wp_error( $result ) ) {
+              charitable_get_notices()->add_errors_from_wp_error( $result );
+              return 0;
+            }
         }
 
         wp_safe_redirect( charitable_get_login_redirect_url() );

--- a/includes/users/class-charitable-user.php
+++ b/includes/users/class-charitable-user.php
@@ -639,8 +639,9 @@ class Charitable_User extends WP_User {
         /* Insert the user */
         if ( 0 == $this->ID ) {         
     
-            if ( ! isset( $values[ 'user_pass' ] ) ) {
-                $values[ 'user_pass' ] = wp_generate_password();
+            if ( ! isset( $values[ 'user_pass' ] ) || strlen( $values[ 'user_pass' ] ) == 0 ) {
+              charitable_get_notices()->add_error( '<strong>ERROR:</strong> Password field is required.' );
+              return 0;
             }       
 
             if ( ! isset( $values[ 'user_login' ] ) ) {

--- a/includes/users/class-charitable-user.php
+++ b/includes/users/class-charitable-user.php
@@ -647,6 +647,13 @@ class Charitable_User extends WP_User {
                 $values[ 'user_login' ] = $values[ 'user_email' ];
             }       
 
+            /**
+             * `wp_insert_user` calls `sanitize_user` internally - make the
+             * same call here so `$values[ 'user_login' ]` matches what is
+             * eventually saved to the database
+             */
+            $values[ 'user_login' ] = sanitize_user( $values[ 'user_login' ], true );
+
             $user_id = wp_insert_user( $values );
 
             if ( is_wp_error( $user_id ) ) {


### PR DESCRIPTION
# Registration Quirks

This pull request address a couple of error scenarios for user registration that produce unexpected results.

The scenarios are:

* Username provided includes invalid characters such as a `+` in the email address (see [Gmail documentation](https://support.google.com/mail/answer/12096?hl=en)).
* User leaves password field empty when filling out registration form

This was prompted by me trying to register with a bogus email address using `+` (as described in Gmail docs), being redirected to a blank registration page, and being confused.

## Username includes an invalid character

### Expected Result

There are two reasonable options here:

0. Decline to create user and return to registration page with error message
0. Create user with sanitized username, log user in, user sees sanitized username somewhere in UI (i.e. admin bar) so they are aware of the updated username

### Actual Result

The user is successfully created, but first, the username is sanitized automatically by a call to  `sanitize_user` inside `wp_insert_user`.  After the user is created, `save_registration()` attempts login with unsanitized username.  Error is never check so user is redirected to page as determined by `redirect_to` in url.  In my case, the `redirect_to` page is campaign creation, which in turn, redirects the user back to the registration page because they are not logged in.  User may try to register again but this time is told that user with that username already exists.  User is :confused: 

### Proposed Solution

Proposed solution is twofold:

0. Handle `wp_signon` errors when logging on after registration just in case there are any - it will be less confusing than potentially being redirected back to a blank registration form
0. Save the sanitized username to the `Charitable_User` object and then use it (via `$user->user_login`) when attempting to log in - this will ensure that we are logging in with the actual username that got saved to the database, even if it is different from what the user originally submitted

This solution is better than declining to create the user, as this solution does not interrupt user campaign creation flow and is therefore less likely to cause the user to bounce

## User leaves password field empty

### Expected Result

There are two reasonable options here:

0. Decline to create user and return to registration page with error message
0. Randomly generate a password for the user
  * In this case, the user should be logged in - while they not be able to log back in later, as they will not know the password, logging them in initially will at least prevent interruption of workflow

### Actual Result

User gets created and some password gets saved.  (*NOTE: I am not 100% what that password is, but I think it's `""`.)  The password saved is not one generated by `wp_generate_password()` because that code is not reached - `$values[ 'user_pass' ]` is set (to empty string), so the `isset` check fails.

In this case, `save_registration()` cannot log the user in because the password is not available, and calling `$user->user_pass` returns the hashed result only.

User is then redirected to `redirect_to` page.  Or, if error handling is implemented as described above, user is redirected to registration page with the error `ERROR: The password field is empty.`  User thinks this message refers to the registration form and not the login attempt - user attempts to re-register after filling in the password field and gets `Sorry, that username already exists!`, is :confused: 

### Proposed Solution

In order to avoid any confusion, and since we cannot retrieve the randomly-generated password from the `$user` object, the proposed solution when the user fails to fill out the password field is to decline user creation and return the user to the registration page with the error message `ERROR: Password field is required.`.  