### PR TITLE
Gateway "supports"

### DIFF
--- a/includes/donations/class-charitable-donation-form.php
+++ b/includes/donations/class-charitable-donation-form.php
@@ -433,7 +433,7 @@ class Charitable_Donation_Form extends Charitable_Form implements Charitable_Don
      * @since   1.0.0
      */
     public function add_credit_card_fields( $fields, Charitable_Gateway $gateway ) {
-        if ( $gateway->requires_credit_card_form() ) {
+        if ( $gateway->supports( 'credit-card' ) ) {
             $fields = array_merge( $fields, $gateway->get_credit_card_fields() );
         }
 

--- a/includes/gateways/abstract-class-charitable-gateway.php
+++ b/includes/gateways/abstract-class-charitable-gateway.php
@@ -44,7 +44,7 @@ abstract class Charitable_Gateway implements Charitable_Gateway_Interface {
      * Supported features such as 'credit-card', and 'recurring' donations
      * @var array
      */
-    public $supports = array();
+    protected $supports = array();
 
     /**
      * Return the gateway name.

--- a/includes/gateways/abstract-class-charitable-gateway.php
+++ b/includes/gateways/abstract-class-charitable-gateway.php
@@ -138,7 +138,7 @@ abstract class Charitable_Gateway implements Charitable_Gateway_Interface {
      * @since   1.0.0
      */
     public function requires_credit_card_form() {
-        _doing_it_wrong( __METHOD__, sprintf( "Use supports('credit-card') method" ), '1.3.0' );
+        _deprecated_function( __METHOD__, sprintf( "Use supports('credit-card') method" ), '1.3.0' );
         return $this->supports( 'credit-card' );
     }
 

--- a/includes/gateways/abstract-class-charitable-gateway.php
+++ b/includes/gateways/abstract-class-charitable-gateway.php
@@ -43,6 +43,8 @@ abstract class Charitable_Gateway implements Charitable_Gateway_Interface {
     /**
      * Supported features such as 'credit-card', and 'recurring' donations
      * @var array
+     * @access  protected
+     * @since   1.3.0
      */
     protected $supports = array();
 

--- a/includes/gateways/abstract-class-charitable-gateway.php
+++ b/includes/gateways/abstract-class-charitable-gateway.php
@@ -152,7 +152,8 @@ abstract class Charitable_Gateway implements Charitable_Gateway_Interface {
      * @since 1.3.0
      */
     public function supports( $feature ) {
-        return apply_filters( 'charitable_payment_gateway_supports', in_array( $feature, $this->supports ) ? true : false, $feature, $this );
+        $supported = in_array( $feature, $this->supports ) ? true : false;
+        return apply_filters( 'charitable_payment_gateway_supports', $supported, $feature, $this );
     }
 
 

--- a/includes/gateways/abstract-class-charitable-gateway.php
+++ b/includes/gateways/abstract-class-charitable-gateway.php
@@ -41,11 +41,10 @@ abstract class Charitable_Gateway implements Charitable_Gateway_Interface {
     protected $defaults;
 
     /**
-     * @var     boolean  Flags whether the gateway requires credit card fields added to the donation form.
-     * @access  protected
-     * @since   1.0.0
+     * Supported features such as 'credit-card', and 'recurring' donations
+     * @var array
      */
-    protected $credit_card_form = false;
+    public $supports = array();
 
     /**
      * Return the gateway name.
@@ -137,8 +136,23 @@ abstract class Charitable_Gateway implements Charitable_Gateway_Interface {
      * @since   1.0.0
      */
     public function requires_credit_card_form() {
-        return $this->credit_card_form;
+        _doing_it_wrong( __METHOD__, sprintf( "Use supports('credit-card') method" ), '1.3.0' );
+        return $this->supports( 'credit-card' );
     }
+
+    /**
+     * Check if a gateway supports a given feature.
+     *
+     * Gateways should override this to declare support (or lack of support) for a feature.
+     *
+     * @param string $feature string The name of a feature to test support for.
+     * @return bool True if the gateway supports the feature, false otherwise.
+     * @since 1.3.0
+     */
+    public function supports( $feature ) {
+        return apply_filters( 'charitable_payment_gateway_supports', in_array( $feature, $this->supports ) ? true : false, $feature, $this );
+    }
+
 
     /**
      * Returns an array of credit card fields.

--- a/includes/gateways/class-charitable-gateway-paypal.php
+++ b/includes/gateways/class-charitable-gateway-paypal.php
@@ -37,6 +37,11 @@ class Charitable_Gateway_Paypal extends Charitable_Gateway {
         $this->defaults = array(
             'label' => __( 'PayPal', 'charitable' )
         );
+
+        $this->supports = array(
+            'recurring'
+        );
+        
     }
 
     /**


### PR DESCRIPTION
Borrowed from WooCommerce, I think this will give us an easy way to test which gateways support which feature. ex: I know that with Recurring I will need to determine if any gateways support a recurring donation. On the front-end I'd use it to show the recurring options or hide them if no appropriate gateway is enabled. On the backend I'd use it to show a warning that recurring donations can't work without an enabled gateway that support it. 