### PR TITLE
Trim the currency symbol before translating to monetary amount

### DIFF
--- a/includes/currency/class-charitable-currency.php
+++ b/includes/currency/class-charitable-currency.php
@@ -124,6 +124,8 @@ final class Charitable_Currency {
 			$amount = str_replace( '_', '.', $amount );
 		}
 
+		$amount = trim( $amount, $this->get_currency_symbol() );
+
 		return floatval( filter_var( $amount, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION ) );
 	}
 


### PR DESCRIPTION
Otherwise, the currency symbol gets treated as a number.  For example, with USD, this will turn $500.00 into $36,500.00