### PR TITLE
Do not attempt to add non-existent donation to donation log

### DIFF
--- a/includes/donations/class-charitable-donation-processor.php
+++ b/includes/donations/class-charitable-donation-processor.php
@@ -530,7 +530,9 @@ if ( ! class_exists( 'Charitable_Donation_Processor' ) ) :
 		 */
 		public function update_donation_log( $donation_id, $message ) {
 			$donation = charitable_get_donation( $donation_id );
-			$donation->update_donation_log( $message );
+			if ( $donation ) {
+				$donation->update_donation_log( $message );
+			}
 		}
 
 		/**


### PR DESCRIPTION
If `charitable_get_donation()` returns something other than a donation, do not attempt to add it to the donation log.  Doing so, produces a 500/server error.  Not doing so allows user to be returned to donation page with error displaying as expected