### PR TITLE
Issues with New Login Workflow

### DIFF
--- a/includes/user-management/charitable-user-management-hooks.php
+++ b/includes/user-management/charitable-user-management-hooks.php
@@ -84,4 +84,4 @@ add_action( 'admin_init', array( Charitable_User_Management::get_instance(), 'ma
  *
  * @see     Charitable_User_Management::redirect_to_charitable_login()
  */
-add_action( 'login_init', array( Charitable_User_Management::get_instance(), 'redirect_to_charitable_login' ) );
+add_action( 'login_form_login', array( Charitable_User_Management::get_instance(), 'redirect_to_charitable_login' ) );

--- a/includes/user-management/charitable-user-management-hooks.php
+++ b/includes/user-management/charitable-user-management-hooks.php
@@ -85,3 +85,12 @@ add_action( 'admin_init', array( Charitable_User_Management::get_instance(), 'ma
  * @see     Charitable_User_Management::redirect_to_charitable_login()
  */
 add_action( 'login_form_login', array( Charitable_User_Management::get_instance(), 'redirect_to_charitable_login' ) );
+
+/**
+ * If hiding all access to wp-login.php using the charitable_disable_wp_login
+ * filter, capture login error messages and display them on the Charitable
+ * login page
+ *
+ * @see     Charitable_User_Management::maybe_redirect_at_authenticate()
+ */
+add_action( 'authenticate', array( Charitable_User_Management::get_instance(), 'maybe_redirect_at_authenticate' ), 101, 3 );

--- a/includes/user-management/charitable-user-management-hooks.php
+++ b/includes/user-management/charitable-user-management-hooks.php
@@ -84,8 +84,4 @@ add_action( 'admin_init', array( Charitable_User_Management::get_instance(), 'ma
  *
  * @see     Charitable_User_Management::redirect_to_charitable_login()
  */
-if ( apply_filters( 'charitable_disable_wp_login', false ) && 'wp' != charitable_get_option( 'login_page', 'wp' ) ) {
-
-	add_action( 'login_init', array( Charitable_User_Management::get_instance(), 'redirect_to_charitable_login' ) );
-
-}
+add_action( 'login_init', array( Charitable_User_Management::get_instance(), 'redirect_to_charitable_login' ) );

--- a/includes/user-management/charitable-user-management-hooks.php
+++ b/includes/user-management/charitable-user-management-hooks.php
@@ -94,3 +94,12 @@ add_action( 'login_form_login', array( Charitable_User_Management::get_instance(
  * @see     Charitable_User_Management::maybe_redirect_at_authenticate()
  */
 add_action( 'authenticate', array( Charitable_User_Management::get_instance(), 'maybe_redirect_at_authenticate' ), 101, 3 );
+
+/**
+ * If hiding all access to wp-login.php using the charitable_disable_wp_login
+ * filter, redirect user to custom forgot password page if they try to directly
+ * access /wp-login.php?action=lostpassword
+ *
+ * @see     Charitable_User_Management::maybe_redirect_to_custom_lostpassword()
+ */
+add_action( 'login_form_lostpassword', array( Charitable_User_Management::get_instance(), 'maybe_redirect_to_custom_lostpassword' ) );

--- a/includes/user-management/charitable-user-management-hooks.php
+++ b/includes/user-management/charitable-user-management-hooks.php
@@ -103,3 +103,13 @@ add_action( 'authenticate', array( Charitable_User_Management::get_instance(), '
  * @see     Charitable_User_Management::maybe_redirect_to_custom_lostpassword()
  */
 add_action( 'login_form_lostpassword', array( Charitable_User_Management::get_instance(), 'maybe_redirect_to_custom_lostpassword' ) );
+
+/**
+ * If hiding all access to wp-login.php using the charitable_disable_wp_login
+ * filter, redirect user to custom reset password page if they try to directly
+ * access /wp-login.php?action=rp or /wp-login.php?action=resetpass
+ *
+ * @see     Charitable_User_Management::maybe_redirect_to_custom_password_reset_page()
+ */
+add_action( 'login_form_rp', array( Charitable_User_Management::get_instance(), 'maybe_redirect_to_custom_password_reset_page' ) );
+add_action( 'login_form_resetpass', array( Charitable_User_Management::get_instance(), 'maybe_redirect_to_custom_password_reset_page' ) );

--- a/includes/user-management/class-charitable-user-management.php
+++ b/includes/user-management/class-charitable-user-management.php
@@ -84,6 +84,38 @@ if ( ! class_exists( 'Charitable_User_Management' ) ) :
 		}
 
 		/**
+		 * Check if user has submitted a login attempt
+		 *
+		 * If so, and charitable_disable_wp_login is set, display errors on
+		 * charitable login page
+		 *
+		 * @return  WP_User|WP_Error|void Redirect if charitable_disable_wp_login is set and there are login errors
+		 * @access  public
+		 * @since   1.4.0
+		 */
+		public function maybe_redirect_at_authenticate( $user_or_error, $username, $password ) {
+			if ( apply_filters( 'charitable_disable_wp_login', false ) && 'wp' != charitable_get_option( 'login_page', 'wp' ) ) {
+				if ( $_SERVER[ 'REQUEST_METHOD' ] == 'POST' ) {
+					if( is_wp_error( $user_or_error ) ) {
+
+						foreach( $user_or_error->get_error_messages()	as $key => $error ) {
+							charitable_get_notices()->add_error( $error );
+						}
+
+						charitable_get_session()->add_notices();
+
+						wp_safe_redirect( esc_url_raw( charitable_get_permalink( 'login_page' ) ) );
+
+						exit();
+
+					}
+				}
+			}
+
+			return $user_or_error;
+		}
+
+		/**
 		 * Set the password reset cookie.
 		 *
 		 * This is based on the WC_Shortcode_My_Account::set_reset_password_cookie()

--- a/includes/user-management/class-charitable-user-management.php
+++ b/includes/user-management/class-charitable-user-management.php
@@ -197,14 +197,13 @@ if ( ! class_exists( 'Charitable_User_Management' ) ) :
 
 			if ( apply_filters( 'charitable_disable_wp_login', false ) && 'wp' != charitable_get_option( 'login_page', 'wp' ) ) {
 				/* Don't prevent logging out. */
-				if ( isset( $_GET['action'] ) && 'logout' == $_GET['action'] ) {
-					return;
+				if ( $_SERVER[ 'REQUEST_METHOD' ] == 'GET' ) {
+
+					wp_safe_redirect( esc_url_raw( charitable_get_permalink( 'login_page' ) ) );
+
+					exit();
+
 				}
-
-				wp_safe_redirect( esc_url_raw( charitable_get_permalink( 'login_page' ) ) );
-
-				exit();
-
 			}
 		}
 

--- a/includes/user-management/class-charitable-user-management.php
+++ b/includes/user-management/class-charitable-user-management.php
@@ -195,15 +195,17 @@ if ( ! class_exists( 'Charitable_User_Management' ) ) :
 		 */
 		public function redirect_to_charitable_login() {
 
-			/* Don't prevent logging out. */
-			if ( isset( $_GET['action'] ) && 'logout' == $_GET['action'] ) {
-				return;
+			if ( apply_filters( 'charitable_disable_wp_login', false ) && 'wp' != charitable_get_option( 'login_page', 'wp' ) ) {
+				/* Don't prevent logging out. */
+				if ( isset( $_GET['action'] ) && 'logout' == $_GET['action'] ) {
+					return;
+				}
+
+				wp_safe_redirect( esc_url_raw( charitable_get_permalink( 'login_page' ) ) );
+
+				exit();
+
 			}
-
-			wp_safe_redirect( esc_url_raw( charitable_get_permalink( 'login_page' ) ) );
-
-			exit();
-
 		}
 
 		/**

--- a/includes/user-management/class-charitable-user-management.php
+++ b/includes/user-management/class-charitable-user-management.php
@@ -116,6 +116,26 @@ if ( ! class_exists( 'Charitable_User_Management' ) ) :
 		}
 
 		/**
+		 * Check if user is attempting to access the forgot password page
+		 *
+		 * If so, and charitable_disable_wp_login is set, redirect them to the custom forgot password page
+		 *
+		 * @return  void
+		 * @access  public
+		 * @since   1.4.0
+		 */
+		public function maybe_redirect_to_custom_lostpassword() {
+			if ( apply_filters( 'charitable_disable_wp_login', false ) && 'wp' != charitable_get_option( 'login_page', 'wp' ) ) {
+				if ( $_SERVER[ 'REQUEST_METHOD' ] == 'GET' ) {
+
+						wp_safe_redirect( esc_url_raw( charitable_get_permalink( 'forgot_password_page' ) ) );
+
+						exit();
+				}
+			}
+		}
+
+		/**
 		 * Set the password reset cookie.
 		 *
 		 * This is based on the WC_Shortcode_My_Account::set_reset_password_cookie()

--- a/includes/user-management/class-charitable-user-management.php
+++ b/includes/user-management/class-charitable-user-management.php
@@ -84,6 +84,28 @@ if ( ! class_exists( 'Charitable_User_Management' ) ) :
 		}
 
 		/**
+		 * Check if user is attempting to access the default reset password page
+		 *
+		 * If so, and charitable_disable_wp_login is set, redirect them to the custom reset password page
+		 *
+		 * @return  void
+		 * @access  public
+		 * @since   1.4.0
+		 */
+		public function maybe_redirect_to_custom_password_reset_page() {
+			if ( apply_filters( 'charitable_disable_wp_login', false ) && 'wp' != charitable_get_option( 'login_page', 'wp' ) ) {
+
+				$redirect_url = charitable_get_permalink( 'reset_password_page' );
+				$redirect_url = add_query_arg( 'login', esc_attr( $_REQUEST['login'] ), $redirect_url );
+				$redirect_url = add_query_arg( 'key', esc_attr( $_REQUEST['key'] ), $redirect_url );
+
+				wp_safe_redirect( esc_url_raw( $redirect_url ) );
+
+				exit();
+			}
+		}
+
+		/**
 		 * Check if user has submitted a login attempt
 		 *
 		 * If so, and charitable_disable_wp_login is set, display errors on

--- a/templates/form-fields/notices.php
+++ b/templates/form-fields/notices.php
@@ -24,7 +24,6 @@ if ( empty( $notices ) ) {
         <?php foreach ( $messages as $message ) : ?>
             <li><?php echo $message ?></li>
         <?php endforeach ?>
-        <li>
     </ul><!-- charitable-notice-<?php esc_attr( $type ) ?> -->
 <?php endforeach ?>
 </div><!-- .charitable-notices -->


### PR DESCRIPTION
Hi @ericnicolaas,

Unfortunately, there are a couple issues with the new code for #89

I have fixed a couple so far:

- [x]  `charitable_disable_wp_login` filter is ignored due to load order - fixed by putting the filter check inside the action
- [x] user is unable to correctly use wp-login.php for POST actions - fixed by using `login_form_login` instead of `login_init`

Here are the issues that remain:

- [x] forgot password page and reset password pages don't work (404)
- [x] if user enters no password, invalid password, or invalid username, error message displays on wp-login.php page and not Charitable login page
- [x] `/wp-login.php?action=lostpassword` is still directly accessible
- [x] wp-login reset password page is still directly accessible

I will continue to take a look at this, as it is top priority.  Feel free to hit me up on chat when you are back at it.
