### PR TITLE
CRITICAL: In charitable_get_user, check for WP_User object and get ID

### DIFF
--- a/includes/users/charitable-user-functions.php
+++ b/includes/users/charitable-user-functions.php
@@ -24,6 +24,9 @@ if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly.
  * @since   1.0.0
  */
 function charitable_get_user( $user_id, $force = false ) {
+	if ( is_a( $user_id, 'WP_User' ) ) {
+		$user_id = $user_id->ID;
+	}
 	$user = wp_cache_get( $user_id, 'charitable_user', $force );
 
 	if ( ! $user ) {


### PR DESCRIPTION
Trying to use a `WP_User` object for `$user_id` in the `charitable_get_user()` function results in the following error:

```
PHP Catchable fatal error:  Object of class WP_User could not be converted to string in <path>/wp-content/object-cache.php on line 350
```

This was brought about by changing `new Charitable_User()` to `charitable_get_user()` in https://github.com/Charitable/Charitable/commit/081b0f85f5037e8cca85c69d4755439aea466282 and it resulted in breaking the account page