### PR TITLE
display all notices. option to make notice dismissible.

### DIFF
--- a/assets/css/scss/public/_notices.scss
+++ b/assets/css/scss/public/_notices.scss
@@ -12,4 +12,22 @@
             list-style: none;
         }        
     }
+
+    &.notice-error {
+
+    }
+
+    &.notice-warning {
+
+    }
+
+    &.notice-info {
+        border-left-color: #f89d35; 
+        background-color: #fef4e8;
+    }
+
+    &.updated {
+
+    }
+
 }

--- a/assets/js/charitable-admin-notice.js
+++ b/assets/js/charitable-admin-notice.js
@@ -20,10 +20,14 @@
                         withCredentials: true
                     },
                     success: function ( response ) {
-                        console.log( response );
+                        if ( window.console && window.console.log ) {
+                            console.log( response );
+                        }
                     },
                     error: function( error ) {
-                        console.log( error );
+                        if ( window.console && window.console.log ) {
+                            console.log( error );
+                        }
                     }
                 }).fail(function ( response ) {
                     if ( window.console && window.console.log ) {

--- a/assets/js/charitable-admin-notice.js
+++ b/assets/js/charitable-admin-notice.js
@@ -2,22 +2,11 @@
 
     $( document ).ready( function() {
 
-        $( '.charitable-notice' ).each( function(){
-            var $el = $( this ),
-                $button = $( '<button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button>' ),
-                btnText = commonL10n.dismiss || '';
+        $( '.charitable-notice.is-dismissible' ).each( function(){
+            var $el = $( this ), $button = $el.find( '.notice-dismiss' );
 
-            // Ensure plain text
-            $button.find( '.screen-reader-text' ).text( btnText );
-            
-            $button.on( 'click.charitable-dismiss-notice', function( event ) {
-                event.preventDefault();
-                
-                $el.fadeTo( 100, 0, function() {
-                    $el.slideUp( 100, function() {
-                        $el.remove();
-                    });
-                });            
+            $button.on( 'click', function( event ) {
+                event.preventDefault();           
 
                 $.ajax({
                     type: "POST",
@@ -43,7 +32,7 @@
                 });
             });
 
-            $el.css( 'position', 'relative' ).append( $button );
+            $el.css( 'position', 'relative' );
         });
     });
 

--- a/includes/admin/class-charitable-admin.php
+++ b/includes/admin/class-charitable-admin.php
@@ -165,24 +165,61 @@ final class Charitable_Admin {
             return;
         }
 
-        $notices = array(
-            'release-140' => sprintf( __( "Thanks for upgrading to Charitable 1.4. <a href='%s'>Find out what's new in this release</a>.", 'charitable' ), 
-                'https://www.wpcharitable.com/charitable-1-4-features-responsive-campaign-grids-a-new-shortcode?utm_source=notice&utm_medium=wordpress-dashboard&utm_campaign=release-notes' ), 
-        );
+        $notice_helper = charitable_get_notices();
 
-        foreach ( $notices as $notice => $message ) {
+        $notice_helper->add_info( sprintf( __( "Thanks for upgrading to Charitable 1.4. <a href='%s'>Find out what's new in this release</a>.", 'charitable' ), 
+                'https://www.wpcharitable.com/charitable-1-4-features-responsive-campaign-grids-a-new-shortcode?utm_source=notice&utm_medium=wordpress-dashboard&utm_campaign=release-notes' ), 'release-140', true );
 
-            if ( ! get_transient( 'charitable_' . $notice . '_notice' ) ) {
+        $notices = $notice_helper->get_notices();
+
+        if ( ! wp_script_is( 'charitable-admin-notice' ) ) {
+                wp_enqueue_script( 'charitable-admin-notice' );
+        }
+
+        // errors
+        foreach ( $notice_helper->get_errors() as $index => $notice ) {
+
+            if ( $notice['dismissible'] && ! get_transient( 'charitable_' . $index . '_notice' ) ) {
                 continue;
             }
 
-            if ( ! wp_script_is( 'charitable-admin-notice' ) ) {
-                wp_enqueue_script( 'charitable-admin-notice' );
-            }
-
-            echo '<div class="updated notice charitable-notice" data-notice="' . esc_attr( $notice ) . '" style="border-left-color: #f89d35; background-color: #fef4e8;"><p>' . $message . '</p></div>';
+            printf( '<div class="notice-error notice charitable-notice %s" data-notice="' . esc_attr( $index ) . '"><p>' . $notice['message'] . '</p></div>', $notice['dismissible'] ? 'is-dismissible' : '' );
             
         }
+
+        // warnings
+        foreach ( $notice_helper->get_warnings() as $index => $notice ) {
+
+            if ( $notice['dismissible'] && ! get_transient( 'charitable_' . $index . '_notice' ) ) {
+                continue;
+            }
+
+            printf( '<div class="notice-warning notice charitable-notice %s" data-notice="' . esc_attr( $index ) . '"><p>' . $notice['message'] . '</p></div>', $notice['dismissible'] ? 'is-dismissible' : '' );
+            
+        }
+
+        // info
+        foreach ( $notice_helper->get_info_notices() as $index => $notice ) {
+
+            if ( $notice['dismissible'] && ! get_transient( 'charitable_' . $index . '_notice' ) ) {
+                continue;
+            }
+
+            printf( '<div class="notice-info notice charitable-notice %s" data-notice="' . esc_attr( $index ) . '"><p>' . $notice['message'] . '</p></div>', $notice['dismissible'] ? 'is-dismissible' : '' );
+            
+        }
+
+        // success
+        foreach ( $notice_helper->get_success_notices() as $index => $notice ) {
+
+            if ( $notice['dismissible'] && ! get_transient( 'charitable_' . $index . '_notice' ) ) {
+                continue;
+            }
+
+            printf( '<div class="updated notice charitable-notice %s" data-notice="' . esc_attr( $index ) . '"><p>' . $notice['message'] . '</p></div>', $notice['dismissible'] ? 'is-dismissible' : '' );
+            
+        }
+
     }
 
     /**

--- a/includes/class-charitable-notices.php
+++ b/includes/class-charitable-notices.php
@@ -84,11 +84,11 @@ if ( ! class_exists( 'Charitable_Notices' ) ) :
 		 * @access  public
 		 * @since 	1.0.0
 		 */
-		public function add_notice( $message, $type, $key = false ) {
+		public function add_notice( $message, $type, $key = false, $dismissible = false  ) {
 			if ( false === $key ) {
-				$this->notices[ $type ][] = $message;
+				$this->notices[ $type ][] = array( 'message' => $message, 'dismissible' => $dismissible );
 			} else {
-				$this->notices[ $type ][ $key ] = $message;
+				$this->notices[ $type ][ $key ] = array( 'message' => $message, 'dismissible' => $dismissible );
 			}
 		}
 
@@ -118,8 +118,8 @@ if ( ! class_exists( 'Charitable_Notices' ) ) :
 		 * @access  public
 		 * @since 	1.0.0
 		 */
-		public function add_error( $message, $key = false ) {
-			$this->add_notice( $message, 'error', $key );
+		public function add_error( $message, $key = false, $dismissible = false ) {
+			$this->add_notice( $message, 'error', $key, $dismissible );
 		}
 
 		/**
@@ -131,8 +131,8 @@ if ( ! class_exists( 'Charitable_Notices' ) ) :
 		 * @access  public
 		 * @since 	1.0.0
 		 */
-		public function add_warning( $message, $key = false ) {
-			$this->add_notice( $message, 'warning', $key );
+		public function add_warning( $message, $key = false, $dismissible = false ) {
+			$this->add_notice( $message, 'warning', $key, $dismissible );
 		}
 
 		/**
@@ -144,8 +144,8 @@ if ( ! class_exists( 'Charitable_Notices' ) ) :
 		 * @access  public
 		 * @since 	1.0.0
 		 */
-		public function add_success( $message, $key = false ) {
-			$this->add_notice( $message, 'success', $key );
+		public function add_success( $message, $key = false, $dismissible = false ) {
+			$this->add_notice( $message, 'success', $key, $dismissible );
 		}
 
 		/**
@@ -157,8 +157,8 @@ if ( ! class_exists( 'Charitable_Notices' ) ) :
 		 * @access  public
 		 * @since 	1.0.0
 		 */
-		public function add_info( $message, $key = false ) {
-			$this->add_notice( $message, 'info', $key );
+		public function add_info( $message, $key = false, $dismissible = false ) {
+			$this->add_notice( $message, 'info', $key, $dismissible );
 		}
 
 		/**


### PR DESCRIPTION
Some new code I was playing around with for displaying any notice. WP supports creating the dismiss button automatically if the message has the class `is-dismissible` so you don't need to add that via your own JS. But some notices (like an error notice) should not be dismissible and may simply resolve on page load (assuming the error goes away). 

Can be used by other charitable plugins to display notices. Just a thing I thought of while trying to display some recurring errors. 

Might need some styling, or you can use the default WP colors. 