### PR TITLE
Fix errors caused by emails trying to fire on charitable-completed status

### DIFF
--- a/includes/admin/campaigns/class-charitable-campaign-post-type.php
+++ b/includes/admin/campaigns/class-charitable-campaign-post-type.php
@@ -56,6 +56,7 @@ if ( ! class_exists( 'Charitable_Campaign_Post_Type' ) ) :
 			add_action( 'charitable_campaign_donation_options_metabox', array( $this, 'campaign_donation_options_metabox' ) );
 			add_filter( 'enter_title_here',                             array( $this, 'campaign_enter_title' ), 10, 2 );
 			add_filter( 'get_user_option_meta-box-order_campaign',      '__return_false' );
+			add_filter( 'post_updated_messages', 						array( $this, 'post_messages' ) );
 			add_filter( 'bulk_post_updated_messages',                   array( $this, 'bulk_messages' ), 10, 2 );
 		}
 
@@ -375,6 +376,32 @@ if ( ! class_exists( 'Charitable_Campaign_Post_Type' ) ) :
 			}
 
 			return $placeholder;
+		}
+
+
+	/**
+	 * Change messages when a post type is updated.
+	 * @param  array $messages
+	 * @return array
+	 */
+	public function post_messages( $messages ) {
+		global $post, $post_ID;
+		$messages[ Charitable::CAMPAIGN_POST_TYPE ] = array(
+			0 => '', // Unused. Messages start at index 1.
+			1 => sprintf( __( 'Campaign updated. <a href="%s">View Campaign</a>', 'charitable' ), esc_url( get_permalink( $post_ID ) ) ),
+			2 => __( 'Custom field updated.', 'charitable' ),
+			3 => __( 'Custom field deleted.', 'charitable' ),
+			4 => __( 'Campaign updated.', 'charitable' ),
+			5 => isset( $_GET['revision'] ) ? sprintf( __( 'Campaign restored to revision from %s', 'charitable' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			6 => sprintf( __( 'Campaign published. <a href="%s">View Campaign</a>', 'charitable' ), esc_url( get_permalink( $post_ID ) ) ),
+			7 => __( 'Campaign saved.', 'charitable' ),
+			8 => sprintf( __( 'Campaign submitted. <a target="_blank" href="%s">Preview Campaign</a>', 'charitable' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) ),
+			9 => sprintf( __( 'Campaign scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview Campaign</a>', 'charitable' ),
+			  date_i18n( __( 'M j, Y @ G:i', 'charitable' ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post_ID ) ) ),
+			10 => sprintf( __( 'Campaign draft updated. <a target="_blank" href="%s">Preview Campaign</a>', 'charitable' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) )
+			);
+
+			return $messages;
 		}
 
 		/**

--- a/includes/admin/donations/class-charitable-donation-post-type.php
+++ b/includes/admin/donations/class-charitable-donation-post-type.php
@@ -75,6 +75,7 @@ if ( ! class_exists( 'Charitable_Donation_Post_Type' ) ) :
 			add_action( 'admin_footer', array( $this, 'bulk_admin_footer' ), 10 );
 			add_action( 'load-edit.php', array( $this, 'process_bulk_action' ) );
 			add_action( 'admin_notices', array( $this, 'bulk_admin_notices' ) );
+			add_filter( 'post_updated_messages', array( $this, 'post_messages' ) );
 			add_filter( 'bulk_post_updated_messages', array( $this, 'bulk_messages' ), 10, 2 );
 
 			// Customization filters
@@ -560,6 +561,31 @@ if ( ! class_exists( 'Charitable_Donation_Post_Type' ) ) :
 			}
 		}
 
+
+	/**
+	 * Change messages when a post type is updated.
+	 * @param  array $messages
+	 * @return array
+	 */
+	public function post_messages( $messages ) {
+		global $post, $post_ID;
+		$messages[ Charitable::DONATION_POST_TYPE ] = array(
+			0 => '', // Unused. Messages start at index 1.
+			1 => sprintf( __( 'Donation updated. <a href="%s">View Donation</a>', 'charitable' ), esc_url( get_permalink( $post_ID ) ) ),
+			2 => __( 'Custom field updated.', 'charitable' ),
+			3 => __( 'Custom field deleted.', 'charitable' ),
+			4 => __( 'Donation updated.', 'charitable' ),
+			5 => isset( $_GET['revision'] ) ? sprintf( __( 'Donation restored to revision from %s', 'charitable' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			6 => sprintf( __( 'Donation published. <a href="%s">View Donation</a>', 'charitable' ), esc_url( get_permalink( $post_ID ) ) ),
+			7 => __( 'Donation saved.', 'charitable' ),
+			8 => sprintf( __( 'Donation submitted. <a target="_blank" href="%s">Preview Donation</a>', 'charitable' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) ),
+			9 => sprintf( __( 'Donation scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview Donation</a>', 'charitable' ),
+			  date_i18n( __( 'M j, Y @ G:i', 'charitable' ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post_ID ) ) ),
+			10 => sprintf( __( 'Donation draft updated. <a target="_blank" href="%s">Preview Donation</a>', 'charitable' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) )
+			);
+
+			return $messages;
+		}
 
 		/**
 		 * Modify bulk messages

--- a/includes/emails/class-charitable-email-donation-receipt.php
+++ b/includes/emails/class-charitable-email-donation-receipt.php
@@ -75,8 +75,14 @@ if ( ! class_exists( 'Charitable_Email_Donation_Receipt' ) ) :
                 return false;
             }
 
+            $donation = charitable_get_donation( $donation_id );
+            
+            if ( ! is_object( $donation ) || empty( $donation->get_campaign_donations() ) || ! apply_filters( 'charitable_send_' . self::get_email_id(), true, $donation ) ){
+                return false;
+            }
+
             $email = new Charitable_Email_Donation_Receipt( array( 
-                'donation' => charitable_get_donation( $donation_id ) 
+                'donation' => $donation
             ) );
 
             /**

--- a/includes/emails/class-charitable-email-new-donation.php
+++ b/includes/emails/class-charitable-email-new-donation.php
@@ -82,8 +82,14 @@ class Charitable_Email_New_Donation extends Charitable_Email {
             return false;
         }
 
+        $donation = charitable_get_donation( $donation_id );
+            
+        if ( ! is_object( $donation ) || empty( $donation->get_campaign_donations() ) || ! apply_filters( 'charitable_send_' . self::get_email_id(), true, $donation ) ){
+            return false;
+        }
+
         $email = new Charitable_Email_New_Donation( array( 
-            'donation' => charitable_get_donation( $donation_id ) 
+            'donation' => $donation
         ) );
 
         /**

--- a/includes/gateways/class-charitable-gateway-paypal.php
+++ b/includes/gateways/class-charitable-gateway-paypal.php
@@ -193,6 +193,10 @@ if ( ! class_exists( 'Charitable_Gateway_Paypal' ) ) :
 			$gateway = new Charitable_Gateway_Paypal();
 			$data    = $gateway->get_encoded_ipn_data();
 
+			if ( defined('CHARITABLE_DEBUG') && CHARITABLE_DEBUG ) {
+			    error_log( json_encode( $data ) );
+			}
+
 			if ( empty( $data ) ) {
 				return false;
 			}


### PR DESCRIPTION
It took my all morning to track this down. Receipts for renewal emails were not sending when I was creating the renewal donation and marking it as completed from the get-go in the `create_renewal_donation()` method of my recurring donation class. 

The trail goes like this: 

The donation receipt email get's the email's recipient from the [donation's donor object](https://github.com/Charitable/Charitable/blob/master/includes/emails/class-charitable-email-donation-receipt.php#L113).

The donation get's it's donor ID from [`get_donor_id()`](https://github.com/Charitable/Charitable/blob/master/includes/donations/abstract-charitable-donation.php#L409) which relies on the campaign donations db table. 

But the campaign donations aren't inserted into that table until [`save_campaign_donations()`](https://github.com/Charitable/Charitable/blob/master/includes/donations/class-charitable-donation-processor.php#L399) in the processor, which is *after* the donation post is created via `wp_insert_post()` (which calls the post status transition hooks). 

SO, if you manually create a donation via `charitable_create_donation()` and directly set the post status as completed then the email will fire at the post status hooks in `wp_insert_post()`... which is before the campaign donations are inserted. Therefore the email will fail because the donation object will not be able to retrieve the donor ID and thus the donor's email.  

Phew. 

Alternatively, it might be nice if the donor ID was attached as meta to the donation post (which I am doing --- er I think I am doing--- for recurring donations). Though you'd have to preserve what you are currently doing for backcompat. 


before the full campaign donations are inserted into DB. Also, add a filter to disable emails.

be9c45ab8c7f57daf53c03524fb7821567ab0c15