### PR TITLE
factory's get_donation() returns false if post is not a supported 

### DIFF
--- a/includes/donations/class-charitable-donation-factory.php
+++ b/includes/donations/class-charitable-donation-factory.php
@@ -46,7 +46,12 @@ class Charitable_Donation_Factory {
 		}
 
 		$donation_id  = absint( $donation->ID );
+		
 		$post_type = $donation->post_type;
+
+		if( ! in_array( $post_type, apply_filters( 'charitable_valid_donation_types', array( Charitable::DONATION_POST_TYPE ) ) ) ){
+			return false;
+		}
 
 		$classname = $this->get_donation_class( $donation );
 


### PR DESCRIPTION
donation type. closes #245. 

Let me know if you want to pull the `apply_filters()` out and then cast the result as an array, ex:

```
$valid_donation_types = apply_filters( 'charitable_valid_donation_types', array( Charitable::DONATION_POST_TYPE ) );

if( ! in_array( $post_type, (array) $valid_donation_types ) ){
     return false;
}
```

Or if you think we ought to use `$post_type = get_post_type( $donation_id );` instead of pulling it out of the post object. The current way should be slightly faster right?

And this works great with Recurring Donations, ex. in my post types class:

```
    /**
     * Set up the class. 
     * 
     * Note that the only way to instantiate an object is with the on_start method, 
     * which can only be called during the start phase. In other words, don't try 
     * to instantiate this object. 
     *
     * @access  private
     * @since   1.0.0
     */
    private function __construct() {    
        add_filter( 'charitable_valid_donation_types', array( $this, 'register_donation_type' ) );
        add_action( 'init', array( $this, 'register_post_types' ), 10 );
        add_action( 'init', array( $this, 'register_post_statuses' ), 10 );
    }

    /**
     * Tell Charitable about the recurring donation type 
     *
     * @param array $types
     * @return  array
     * @access  public
     * @since   1.0.0
     */
    public function register_donation_type( $types ) {
        $types[] = Charitable_Recurring::POST_TYPE;
        return $types;
    }
```
