### PR TITLE
save the paypal transaction ID. closes #270.

### DIFF
--- a/includes/db/class-charitable-donors-db.php
+++ b/includes/db/class-charitable-donors-db.php
@@ -189,7 +189,7 @@ if ( ! class_exists( 'Charitable_Donors_DB' ) ) :
 				$status_clause = "AND p.post_status IN ( $in )";
 			}
 
-			$sql = "SELECT COUNT( * )
+			$sql = "SELECT COUNT( DISTINCT(d.donor_id) )
                 FROM {$wpdb->prefix}charitable_donors d
                 INNER JOIN {$wpdb->prefix}charitable_campaign_donations cd ON cd.donor_id = d.donor_id
                 INNER JOIN $wpdb->posts p ON cd.donation_id = p.ID

--- a/includes/gateways/class-charitable-gateway-paypal.php
+++ b/includes/gateways/class-charitable-gateway-paypal.php
@@ -352,6 +352,9 @@ if ( ! class_exists( 'Charitable_Gateway_Paypal' ) ) :
 
 			}
 
+			/* Save the transation ID */
+			$donation->set_gateway_transaction_id( $data['txn_id'] );
+
 			/* Process a completed donation. */
 			if ( 'completed' == $payment_status ) {
 


### PR DESCRIPTION
I think it's in the right spot? It should only catch the transaction ID for pending/completed transactions. 
