### PR TITLE
a11y - Settings Heading

### DIFF
--- a/includes/admin/class-charitable-admin-pages.php
+++ b/includes/admin/class-charitable-admin-pages.php
@@ -150,7 +150,7 @@ if ( ! class_exists( 'Charitable_Admin_Pages' ) ) :
 					'menu_slug'     => 'edit-tags.php?taxonomy=campaign_tag&post_type=campaign',
 				),
 				array(
-					'page_title'    => __( 'Settings', 'charitable' ),
+					'page_title'    => __( 'Charitable Settings', 'charitable' ),
 					'menu_title'    => __( 'Settings', 'charitable' ),
 					'menu_slug'     => 'charitable-settings',
 					'function'      => array( $this, 'render_settings_page' ),

--- a/includes/admin/views/settings/settings.php
+++ b/includes/admin/views/settings/settings.php
@@ -13,6 +13,7 @@ $group      = isset( $_GET['group'] ) ? $_GET['group'] : $active_tab;
 ob_start();
 ?>
 <div id="charitable-settings" class="wrap">
+	<h1><?php echo get_admin_page_title(); ?></ha>
 	<h2 class="nav-tab-wrapper">
 		<?php foreach ( charitable_get_admin_settings()->get_sections() as $tab => $name ) : ?>
 			<a href="<?php echo esc_url( add_query_arg( array( 'tab' => $tab ), admin_url( 'admin.php?page=charitable-settings' ) ) ) ?>" class="nav-tab <?php echo $active_tab == $tab ? 'nav-tab-active' : '' ?>"><?php echo $name ?></a>

--- a/includes/admin/views/settings/settings.php
+++ b/includes/admin/views/settings/settings.php
@@ -13,7 +13,7 @@ $group      = isset( $_GET['group'] ) ? $_GET['group'] : $active_tab;
 ob_start();
 ?>
 <div id="charitable-settings" class="wrap">
-	<h1><?php echo get_admin_page_title(); ?></ha>
+	<h1 class="screen-reader-text"><?php echo get_admin_page_title(); ?></ha>
 	<h2 class="nav-tab-wrapper">
 		<?php foreach ( charitable_get_admin_settings()->get_sections() as $tab => $name ) : ?>
 			<a href="<?php echo esc_url( add_query_arg( array( 'tab' => $tab ), admin_url( 'admin.php?page=charitable-settings' ) ) ) ?>" class="nav-tab <?php echo $active_tab == $tab ? 'nav-tab-active' : '' ?>"><?php echo $name ?></a>


### PR DESCRIPTION
From an a11y point of view, you should always have `<h1>` heading in all the backend pages.

From a UI/UX point of view, you can hide this heading from the regular users using the `screen-reader-text` css class.

This way assistive-technologies and screen-readers will have both H1 and H2 heading for blind people, but the regular people won't see the H1 title.


![1111](https://cloud.githubusercontent.com/assets/576623/21875179/c0bec892-d882-11e6-9be4-eaf7820c4b00.png)
