### PR TITLE
a11y - "title" Attributes

### DIFF
--- a/includes/admin/donations/class-charitable-donation-post-type.php
+++ b/includes/admin/donations/class-charitable-donation-post-type.php
@@ -252,7 +252,7 @@ if ( ! class_exists( 'Charitable_Donation_Post_Type' ) ) :
 						'action' => 'edit',
 					), admin_url( 'post.php' ) ) );
 
-					$display = sprintf( '<a href="%s" title="%s">%s</a>', $url, $title, $text );
+					$display = sprintf( '<a href="%s" aria-label="%s">%s</a>', $url, $title, $text );
 
 					break;
 
@@ -368,7 +368,7 @@ if ( ! class_exists( 'Charitable_Donation_Post_Type' ) ) :
 					'action' => 'edit',
 				), admin_url( 'post.php' ) ) );
 
-				$actions['edit'] = sprintf( '<a href="%s" title="%s">%s</a>', $url, $title, $text );
+				$actions['edit'] = sprintf( '<a href="%s" aria-label="%s">%s</a>', $url, $title, $text );
 
 			}
 

--- a/includes/admin/views/settings/paypal-sandbox-test.php
+++ b/includes/admin/views/settings/paypal-sandbox-test.php
@@ -70,7 +70,7 @@ endif ?>
 				</tr>
 				<tr>
 					<td colspan="2" style="padding: 0 0 15px 0;">
-						<p><?php printf( __( "In October 2016, PayPal is upgrading the SSL certificates used to secure its web sites and API endpoints. <a href='%s' title='How PayPal\'s SSL Certificate Upgrade Will Affect You — And How You Can Prepare for It'>Read about how these changes will impact you.</a>", 'charitable' ),
+						<p><?php printf( __( "In October 2016, PayPal is upgrading the SSL certificates used to secure its web sites and API endpoints. <a href='%s'>Read about how these changes will impact you.</a>", 'charitable' ),
 							'https://www.wpcharitable.com/how-paypals-ssl-certificate-upgrade-will-affect-you-and-how-you-can-prepare-for-it/?utm_source=notice&utm_medium=wordpress-dashboard&utm_campaign=paypal-ssl-upgrade&utm_content=blog-post'
 						) ?></p>						
 						<p><?php printf(

--- a/includes/admin/views/welcome-page/page.php
+++ b/includes/admin/views/welcome-page/page.php
@@ -149,7 +149,7 @@ if ( 'en_ZA' == $locale || 'ZAR' == $currency ) {
                 ) ?></p>
                 <hr />
             <?php endif ?>         
-            <img src="<?php echo charitable()->get_path( 'assets', false ) ?>images/reach-mockup.png" alt="<?php _e( 'Screenshot of Reach, a WordPress fundraising theme designed to complement Charitable', 'charitable' ) ?>" title="<?php _e( 'Reach is a WordPress fundraising theme designed to complement Charitable', 'charitable' ) ?>" style="margin-bottom: 21px;" width="336" height="166" />
+            <img src="<?php echo charitable()->get_path( 'assets', false ) ?>images/reach-mockup.png" alt="<?php _e( 'Screenshot of Reach, a WordPress fundraising theme designed to complement Charitable', 'charitable' ) ?>" style="margin-bottom: 21px;" width="336" height="166" />
             <h2><?php _e( 'Try Reach, a free theme designed for fundraising', 'charitable' ) ?></h2>
             <p><?php _e( 'We built Reach to help non-profits &amp; social entrepreneurs run beautiful online fundraising campaigns. Whether you’re creating a website for your organization’s peer-to-peer fundraising event or building an online crowdfunding platform, Reach is the perfect starting point.', 'charitable' ) ?></p>
             <p><a href="https://www.wpcharitable.com/download-reach/?utm_source=welcome-page&amp;utm_medium=wordpress-dashboard&amp;utm_campaign=reach" class="button-primary" style="margin-right: 8px;" target="_blank"><?php _e( 'Download it free', 'charitable' ) ?></a><a href="http://demo.wpcharitable.com/reach/?utm_source=welcome-page&amp;utm_medium=wordpress-dashboard&amp;utm_campaign=reach" class="button-secondary" target="_blank"><?php _e( 'View demo', 'charitable' ) ?></a></p>

--- a/includes/donations/abstract-charitable-donation.php
+++ b/includes/donations/abstract-charitable-donation.php
@@ -226,7 +226,7 @@ if ( ! class_exists( 'Charitable_Abstract_Donation' ) ) :
 
 				if ( ! isset( $links[ $campaign->campaign_id ] ) ) {
 
-					$links[ $campaign->campaign_id ] = sprintf( '<a href="%s" title="%s">%s</a>',
+					$links[ $campaign->campaign_id ] = sprintf( '<a href="%s" aria-label="%s">%s</a>',
 						get_permalink( $campaign->campaign_id ),
 						sprintf( '%s %s', _x( 'Go to', 'go to campaign', 'charitable' ), get_the_title( $campaign->campaign_id ) ),
 						get_the_title( $campaign->campaign_id )

--- a/includes/emails/abstract-class-charitable-email.php
+++ b/includes/emails/abstract-class-charitable-email.php
@@ -335,14 +335,13 @@ if ( ! class_exists( 'Charitable_Email' ) ) :
 				'preview' => array(
 					'type'      => 'content',
 					'title'     => __( 'Preview', 'charitable' ),
-					'content'   => sprintf( '<a href="%s" title="%s" target="_blank" class="button">%s</a>',
+					'content'   => sprintf( '<a href="%s" target="_blank" class="button">%s</a>',
 						esc_url(
 							add_query_arg( array(
 								'charitable_action' => 'preview_email',
 								'email_id' => $this->get_email_id(),
 							), home_url() )
 						),
-						__( 'Preview email in your browser', 'charitable' ),
 						__( 'Preview email', 'charitable' )
 					),
 					'priority'  => 18,

--- a/includes/user-management/class-charitable-registration-form.php
+++ b/includes/user-management/class-charitable-registration-form.php
@@ -226,9 +226,8 @@ if ( ! class_exists( 'Charitable_Registration_Form' ) ) :
 				$login_link = add_query_arg( 'redirect_to', $_GET['redirect_to'], $login_link );
 			}
 
-			return sprintf( '<a href="%1$s" title="%2$s">%3$s</a>',
+			return sprintf( '<a href="%1$s">%2$s</a>',
 				esc_url( $login_link ),
-				esc_attr( $this->shortcode_args['login_link_text'] ),
 				$this->shortcode_args['login_link_text']
 			);
 		}

--- a/templates/campaign-loop/donate-link.php
+++ b/templates/campaign-loop/donate-link.php
@@ -22,5 +22,5 @@ endif;
 
 ?>
 <div class="campaign-donation">
-	<a class="donate-button button" href="<?php echo charitable_get_permalink( 'campaign_donation_page', array( 'campaign_id' => $campaign->ID ) ) ?>" title="<?php echo esc_attr( sprintf( _x( 'Make a donation to %s', 'make a donation to campaign', 'charitable' ), get_the_title( $campaign->ID ) ) ) ?>"><?php _e( 'Donate', 'charitable' ) ?></a>
+	<a class="donate-button button" href="<?php echo charitable_get_permalink( 'campaign_donation_page', array( 'campaign_id' => $campaign->ID ) ) ?>" aria-label="<?php echo esc_attr( sprintf( _x( 'Make a donation to %s', 'make a donation to campaign', 'charitable' ), get_the_title( $campaign->ID ) ) ) ?>"><?php _e( 'Donate', 'charitable' ) ?></a>
 </div>

--- a/templates/campaign-loop/donate-modal.php
+++ b/templates/campaign-loop/donate-modal.php
@@ -17,7 +17,7 @@ $campaign = $view_args['campaign'];
 		data-campaign-id="<?php echo $campaign->ID ?>"
 		class="donate-button button" 
 		href="<?php echo esc_url( charitable_get_permalink( 'campaign_donation_page', array( 'campaign_id' => $campaign->ID ) ) ) ?>" 
-		title="<?php esc_attr_e( sprintf( _x( 'Make a donation to %s', 'make a donation to campaign', 'charitable' ), get_the_title( $campaign->ID ) ) ) ?>">
+		aria-label="<?php esc_attr_e( sprintf( _x( 'Make a donation to %s', 'make a donation to campaign', 'charitable' ), get_the_title( $campaign->ID ) ) ) ?>">
 		<?php _e( 'Donate', 'charitable' ) ?>
 	</a>
 </div>

--- a/templates/campaign-loop/more-link.php
+++ b/templates/campaign-loop/more-link.php
@@ -20,4 +20,4 @@ if ( $campaign->has_ended() ) :
 endif;
 
 ?>
-<p><a class="button" href="<?php echo get_permalink( $campaign->ID ) ?>" title="<?php echo esc_attr( sprintf( _x( 'Continue reading about %s', 'Continue reading about campaign', 'charitable' ), get_the_title( $campaign->ID ) ) ) ?>"><?php _e( 'Read More', 'charitable' ) ?></a></p>
+<p><a class="button" href="<?php echo get_permalink( $campaign->ID ) ?>" aria-label="<?php echo esc_attr( sprintf( _x( 'Continue reading about %s', 'Continue reading about campaign', 'charitable' ), get_the_title( $campaign->ID ) ) ) ?>"><?php _e( 'Read More', 'charitable' ) ?></a></p>

--- a/templates/campaign/donate-link.php
+++ b/templates/campaign/donate-link.php
@@ -20,5 +20,5 @@ endif;
 
 ?>
 <div class="campaign-donation">
-	<a class="donate-button button" href="#charitable-donation-form" title="<?php echo esc_attr( sprintf( _x( 'Make a donation to %s', 'make a donation to campaign', 'charitable' ), get_the_title( $campaign->ID ) ) ) ?>"><?php _e( 'Donate', 'charitable' ) ?></a>
+	<a class="donate-button button" href="#charitable-donation-form" aria-label="<?php echo esc_attr( sprintf( _x( 'Make a donation to %s', 'make a donation to campaign', 'charitable' ), get_the_title( $campaign->ID ) ) ) ?>"><?php _e( 'Donate', 'charitable' ) ?></a>
 </div>

--- a/templates/campaign/donate-modal.php
+++ b/templates/campaign/donate-modal.php
@@ -14,7 +14,7 @@ $campaign = $view_args['campaign'];
 	<a data-trigger-modal="charitable-donation-form-modal"
 		class="donate-button button"
 		href="<?php echo charitable_get_permalink( 'campaign_donation_page', array( 'campaign_id' => $campaign->ID ) ) ?>" 
-		title="<?php printf( esc_attr_x( 'Make a donation to %s', 'make a donation to campaign', 'charitable' ), get_the_title( $campaign->ID ) ) ?>">
+		aria-label="<?php printf( esc_attr_x( 'Make a donation to %s', 'make a donation to campaign', 'charitable' ), get_the_title( $campaign->ID ) ) ?>">
 	<?php _e( 'Donate', 'charitable' ) ?>
 	</a>
 </div>


### PR DESCRIPTION
**This PR removes some `title` attributes and replaces others with `aria-label` for better accessibility.**

----

From an a11y perspective, you should use the title attribute in HTML tags carefully.

A good example is:

`<a href="">View</a>`

View what?

`<a href="" title="View Donation">View</a>`

Regular user can understand from the design that is the "View" link means. But blind people don't see the context. The `title` attr help them to understand the link context.

A better way is to use `aria-label`, this way it will effect only on the screen-reader.

`<a href="" aria-label="View Donation">View</a>`

BUT, in cases like this:

`<a href="" title="View Donation">View Donation</a>`

The title attribute doe's not add any information. In those cases you should remove the attribute because the screen-reader reads the same text twice.

----

As for `<img>` tags, you should use only `alt` attributes. When you add the `title` attribute, the screen-reader reads the text twice.