### PR TITLE
Globals - deprecate $wp_version global

### DIFF
--- a/includes/admin/donations/class-charitable-donation-post-type.php
+++ b/includes/admin/donations/class-charitable-donation-post-type.php
@@ -55,7 +55,7 @@ if ( ! class_exists( 'Charitable_Donation_Post_Type' ) ) :
 		 * @since   1.0.0
 		 */
 		private function __construct() {
-			global $wp_version;
+			$wp_version = get_bloginfo( 'version' );
 
 			$this->meta_box_helper = new Charitable_Meta_Box_Helper( 'charitable-donation' );
 

--- a/includes/licensing/class-charitable-plugin-updater.php
+++ b/includes/licensing/class-charitable-plugin-updater.php
@@ -226,7 +226,7 @@ class Charitable_Plugin_Updater {
      */
     private function api_request( $action, $data ) {
 
-        global $wp_version;
+        $wp_version = get_bloginfo( 'version' );
 
         $data = array_merge( $this->api_data, $data );
 


### PR DESCRIPTION
Use `get_bloginfo( 'version' )` instead of `global $wp_version`

See WordPress trac changeset: https://core.trac.wordpress.org/changeset/38459