### PR TITLE
Removed Deprecated PayPal Variables (cbt, no_name) - Fixes #413

### DIFF
--- a/includes/admin/views/settings/paypal-sandbox-test.php
+++ b/includes/admin/views/settings/paypal-sandbox-test.php
@@ -52,13 +52,11 @@ endif ?>
 		<input type="hidden" name="item_name" value="<?php esc_attr_e( 'Sandbox Test Donation', 'charitable' ) ?>" />
 		<input type="hidden" name="no_shipping" value="1" />
 		<input type="hidden" name="shipping" value="0" />
-		<input type="hidden" name="no_note" value="1" />
 		<input type="hidden" name="currency_code" value="<?php echo esc_attr( charitable_get_currency() ) ?>" />
 		<input type="hidden" name="charset" value="<?php echo esc_attr( get_bloginfo( 'charset' ) ) ?>" />
 		<input type="hidden" name="rm" value="2" />
 		<input type="hidden" name="return" value="<?php echo esc_url( $return_url ) ?>" />
 		<input type="hidden" name="notify_url" value="<?php echo esc_url( $notify_url ) ?>" />
-		<input type="hidden" name="cbt" value="<?php echo esc_attr( get_bloginfo( 'name' ) ) ?>" />
 		<input type="hidden" name="bn" value="Charitable_SP" />
 		<input type="hidden" name="cmd" value="<?php echo $mode ?>" />
 		<input type="hidden" name="country" value="<?php echo esc_attr( charitable_get_option( 'country', 'AU' ) ) ?>" />        

--- a/includes/gateways/class-charitable-gateway-paypal.php
+++ b/includes/gateways/class-charitable-gateway-paypal.php
@@ -152,7 +152,6 @@ if ( ! class_exists( 'Charitable_Gateway_Paypal' ) ) :
 				'item_name'     => html_entity_decode( $donation->get_campaigns_donated_to(), ENT_COMPAT, 'UTF-8' ),
 				'no_shipping'   => '1',
 				'shipping'      => '0',
-				'no_note'       => '1',
 				'currency_code' => charitable_get_currency(),
 				'charset'       => get_bloginfo( 'charset' ),
 				// 'custom'        => json_encode( array( 'donation_id' => $donation_id, 'donation_key' => $donation_key ) ),
@@ -161,7 +160,6 @@ if ( ! class_exists( 'Charitable_Gateway_Paypal' ) ) :
 				'return'        => charitable_get_permalink( 'donation_receipt_page', array( 'donation_id' => $donation_id ) ),
 				'cancel_return' => charitable_get_permalink( 'donation_cancel_page', array( 'donation_id' => $donation_id ) ),
 				'notify_url'    => charitable_get_ipn_url( Charitable_Gateway_Paypal::ID ),
-				'cbt'           => get_bloginfo( 'name' ),
 				'bn'            => 'Charitable_SP',
 				'cmd'           => 'donations' == $transaction_mode ? '_donations' : '_xclick',
 			), $donation_id, $processor );


### PR DESCRIPTION
Fixes #413 

Made changes in `includes/admin/views/settings/paypal-sandbox-test.php`& `includes/gateways/class-charitable-gateway-paypal.php`

From searching through the repo and viewing other files, I believe these are the only references to these variables, and due to this, the change should not have any side-effects, since the issue was relatively self-contained.