### PR TITLE
Recurring/metabox tweaks

### DIFF
--- a/includes/admin/forms/class-charitable-admin-form.php
+++ b/includes/admin/forms/class-charitable-admin-form.php
@@ -72,7 +72,7 @@ if ( ! class_exists( 'Charitable_Admin_Form' ) ) :
          * @return void
          */
         public function set_fields( array $fields ) {
-            usort( $fields, 'charitable_priority_sort' );
+            uasort( $fields, 'charitable_priority_sort' );
             $this->fields = $fields;
         }
 

--- a/includes/admin/forms/views/class-charitable-admin-form-view.php
+++ b/includes/admin/forms/views/class-charitable-admin-form-view.php
@@ -4,7 +4,7 @@
  *
  * This is responsible for rendering the output of forms in the WordPress dashboard.
  *
- * @version   1.5.3
+ * @version   1.5.7
  * @package   Charitable/Forms/Charitable_Admin_Form_View
  * @author    Eric Daams
  * @copyright Copyright (c) 2017, Studio 164a
@@ -260,7 +260,7 @@ if ( ! class_exists( 'Charitable_Admin_Form_View' ) ) :
         /**
          * Return the field wrapper class.
          *
-         * @since  1.5.3
+         * @since  1.5.7
          *
          * @param  array $field Field definition.
          * @return string

--- a/includes/admin/forms/views/class-charitable-admin-form-view.php
+++ b/includes/admin/forms/views/class-charitable-admin-form-view.php
@@ -4,7 +4,7 @@
  *
  * This is responsible for rendering the output of forms in the WordPress dashboard.
  *
- * @version   1.5.0
+ * @version   1.5.3
  * @package   Charitable/Forms/Charitable_Admin_Form_View
  * @author    Eric Daams
  * @copyright Copyright (c) 2017, Studio 164a
@@ -168,7 +168,7 @@ if ( ! class_exists( 'Charitable_Admin_Form_View' ) ) :
             $field['view']       = $this->get_field_view( $field );
             $field['type']       = $this->get_field_type( $field );
             $field['key']        = $this->get_field_key( $field, $key );            
-            $field['id']         = str_replace( '_', '-', ltrim( $field['key'] ) );
+            $field['id']         = $this->get_field_id( $field );            
             $field['wrapper_id'] = 'charitable-' . $field['id'] . '-wrap';
             $field['tabindex']   = array_key_exists( 'tabindex', $field ) ? (int) $field['tabindex'] : $this->tabindex;
 
@@ -273,6 +273,22 @@ if ( ! class_exists( 'Charitable_Admin_Form_View' ) ) :
             }
 
             return $default;
+        }
+
+        /**
+         * Return the ID for a particular field.
+         *
+         * @since  1.5.3
+         *
+         * @param  array  $field   Field definition.
+         * @param  string $default The key of the form field. This is the fallback option.
+         * @return string
+         */
+        protected function get_field_id( $field ) {
+            if ( array_key_exists( 'id', $field ) ) {
+                return $field['id'];
+            }
+            return str_replace( '_', '-', trim( preg_replace( "![^a-z0-9]+!i", "-", $field['key'] ), '-') );
         }
 
         /**

--- a/includes/admin/forms/views/class-charitable-admin-form-view.php
+++ b/includes/admin/forms/views/class-charitable-admin-form-view.php
@@ -170,6 +170,7 @@ if ( ! class_exists( 'Charitable_Admin_Form_View' ) ) :
             $field['key']        = $this->get_field_key( $field, $key );            
             $field['id']         = $this->get_field_id( $field );            
             $field['wrapper_id'] = 'charitable-' . $field['id'] . '-wrap';
+            $field['wrapper_class'] = $this->get_field_class( $field );
             $field['tabindex']   = array_key_exists( 'tabindex', $field ) ? (int) $field['tabindex'] : $this->tabindex;
 
             if ( 'checkbox' == $field['type'] ) {
@@ -255,6 +256,30 @@ if ( ! class_exists( 'Charitable_Admin_Form_View' ) ) :
 
             return str_replace( 'metaboxes/field-types/', '', $field['view'] );
         }
+
+        /**
+         * Return the field wrapper class.
+         *
+         * @since  1.5.3
+         *
+         * @param  array $field Field definition.
+         * @return string
+         */
+        protected function get_field_class( $field ) {
+
+            $classes = array( 
+                'charitable-metabox-wrap', 
+                'charitable-'. $this->get_field_type( $field ) . '-wrap' 
+            );
+            if ( array_key_exists( 'wrapper_class', $field ) ) {
+                $classes = array_merge( $classes, $field['wrapper_class'] );
+            }
+
+            return implode( ' ', $classes );
+
+        }
+
+        
 
         /**
          * Return the key for a particular field.

--- a/includes/admin/views/metaboxes/field-types/campaign-donations.php
+++ b/includes/admin/views/metaboxes/field-types/campaign-donations.php
@@ -28,7 +28,7 @@ if ( empty( $campaign_donations ) ) {
 }
 
 ?>
-<div id="charitable-campaign-donations-metabox-wrap" class="charitable-metabox-wrap charitable-repeatable-field-wrapper">
+<div id="charitable-campaign-donations-metabox-wrap" class="<?php echo esc_attr( $view_args['wrapper_class'] );?>">
 	<table id="charitable-campaign-donations" class="widefat">
 		<thead>
 			<tr class="table-header">

--- a/includes/admin/views/metaboxes/field-types/checkbox.php
+++ b/includes/admin/views/metaboxes/field-types/checkbox.php
@@ -14,7 +14,7 @@ if ( ! array_key_exists( 'form_view', $view_args ) || ! $view_args['form_view']-
 }
 
 ?>
-<div id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="charitable-metabox-wrap charitable-checkbox-wrap">
+<div id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="<?php echo esc_attr( $view_args['wrapper_class'] );?>">
     <input type="checkbox" id="<?php echo esc_attr( $view_args['id'] ) ?>" name="<?php echo esc_attr( $view_args['key'] ) ?>"  tabindex="<?php echo esc_attr( $view_args['tabindex'] ) ?>" <?php checked( $view_args['checked'] ) ?> />
     <?php if ( isset( $view_args['label'] ) ) : ?>
         <label for="<?php echo esc_attr( $view_args['id'] ) ?>"><?php echo $view_args['label'] ?></label>

--- a/includes/admin/views/metaboxes/field-types/datepicker.php
+++ b/includes/admin/views/metaboxes/field-types/datepicker.php
@@ -15,7 +15,7 @@ if ( ! array_key_exists( 'form_view', $view_args ) || ! $view_args['form_view']-
 $date = array_key_exists( 'value', $view_args ) ? 'data-date="' . esc_attr( $view_args['value'] ) . '"' : '';
 
 ?>
-<div id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="charitable-metabox-wrap charitable-datepicker-wrap">
+<div id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="<?php echo esc_attr( $view_args['wrapper_class'] );?>">
     <?php if ( isset( $view_args['label'] ) ) : ?>
         <label for="<?php echo esc_attr( $view_args['id'] ) ?>"><?php echo $view_args['label'] ?></label>
     <?php endif ?>

--- a/includes/admin/views/metaboxes/field-types/default.php
+++ b/includes/admin/views/metaboxes/field-types/default.php
@@ -14,7 +14,7 @@ if ( ! array_key_exists( 'form_view', $view_args ) || ! $view_args['form_view']-
 }
 
 ?>
-<div id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="charitable-metabox-wrap charitable-<?php echo esc_attr( $view_args['type'] ) ?>-field-wrap">
+<div id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="<?php echo esc_attr( $view_args['wrapper_class'] );?>">
 	<?php if ( isset( $view_args['label'] ) ) : ?>
 		<label for="<?php echo esc_attr( $view_args['id'] ) ?>"><?php echo $view_args['label']  ?></label>
 	<?php endif ?>

--- a/includes/admin/views/metaboxes/field-types/fieldset.php
+++ b/includes/admin/views/metaboxes/field-types/fieldset.php
@@ -13,7 +13,7 @@ if ( ! array_key_exists( 'form_view', $view_args ) || ! $view_args['form_view']-
 }
 
 ?>
-<fieldset id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="charitable-metabox-wrap charitable-fieldset-wrap" <?php echo charitable_get_arbitrary_attributes( $view_args ) ?>>
+<fieldset id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="<?php echo esc_attr( $view_args['wrapper_class'] );?>" <?php echo charitable_get_arbitrary_attributes( $view_args ) ?>>
     <?php if ( array_key_exists( 'legend', $view_args ) ) : ?>
         <h4 class="charitable-metabox-header charitable-fieldset-header"><?php echo $view_args['legend'] ?></h4>
     <?php endif;

--- a/includes/admin/views/metaboxes/field-types/select.php
+++ b/includes/admin/views/metaboxes/field-types/select.php
@@ -14,7 +14,7 @@ if ( ! array_key_exists( 'form_view', $view_args ) || ! $view_args['form_view']-
 }
 
 ?>
-<div id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="charitable-metabox-wrap charitable-select-wrap">
+<div id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="<?php echo esc_attr( $view_args['wrapper_class'] );?>">
 	<?php if ( isset( $view_args['label'] ) ) : ?>
 		<label for="<?php echo esc_attr( $view_args['id'] ) ?>"><?php echo $view_args['label']  ?></label>
 	<?php endif ?>

--- a/includes/admin/views/metaboxes/field-types/text.php
+++ b/includes/admin/views/metaboxes/field-types/text.php
@@ -14,7 +14,7 @@ if ( ! array_key_exists( 'form_view', $view_args ) || ! $view_args['form_view']-
 }
 
 ?>
-<div id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="charitable-metabox-wrap charitable-text-field-wrap">
+<div id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="<?php echo esc_attr( $view_args['wrapper_class'] );?>">
 	<?php if ( isset( $view_args['label'] ) ) : ?>
 		<label for="<?php echo esc_attr( $view_args['id'] ) ?>"><?php echo $view_args['label']  ?></label>
 	<?php endif ?>

--- a/includes/admin/views/metaboxes/field-types/textarea.php
+++ b/includes/admin/views/metaboxes/field-types/textarea.php
@@ -13,7 +13,7 @@ if ( ! array_key_exists( 'form_view', $view_args ) || ! $view_args['form_view']-
 }
 
 ?>
-<div id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="charitable-metabox-wrap charitable-textarea-wrap">
+<div id="<?php echo esc_attr( $view_args['wrapper_id'] ) ?>" class="<?php echo esc_attr( $view_args['wrapper_class'] );?>">
 	<?php if ( isset( $view_args['label'] ) ) : ?>
         <label for="<?php echo esc_attr( $view_args['id'] ) ?>"><?php echo $view_args['label'] ?></label>
     <?php endif ?>


### PR DESCRIPTION
Proposal to allow metaboxes to have different keys/IDs. Or at least to strip out preceding `-` when creating the ID... my keys are are prefaced by an `_` and so the ID's and wrapped IDs were all `-donation-period` or `chariatable--donation-period-wrapper` with lots of stray prefixing hyphens. 

Also add support for custom CSS wrapper classes for the field divs. This will allow easier jquery toggling hide/show based on class instead of having to use ID selectors. 