### PR TITLE
Metabox fields require a Charitable_Donation class causes fatal error…

### DIFF
--- a/includes/donations/charitable-donation-functions.php
+++ b/includes/donations/charitable-donation-functions.php
@@ -40,11 +40,11 @@ function charitable_get_donation( $donation_id, $force = false ) {
  *
  * @since  1.5.0
  *
- * @param  Charitable_Donation $donation The donation ID.
+ * @param  Charitable_Abstract_Donation $donation The donation ID.
  * @param  string              $key      The meta key.
  * @return mixed
  */
-function charitable_get_donor_meta_value( Charitable_Donation $donation, $key ) {
+function charitable_get_donor_meta_value( Charitable_Abstract_Donation $donation, $key ) {
     return $donation->get_donor()->get_donor_meta( $key );
 }
 
@@ -53,11 +53,11 @@ function charitable_get_donor_meta_value( Charitable_Donation $donation, $key ) 
  *
  * @since  1.5.0
  *
- * @param  Charitable_Donation $donation The donation ID.
+ * @param  Charitable_Abstract_Donation $donation The donation ID.
  * @param  string              $key      The meta key.
  * @return mixed
  */
-function charitable_get_donation_meta_value( Charitable_Donation $donation, $key ) {
+function charitable_get_donation_meta_value( Charitable_Abstract_Donation $donation, $key ) {
     return get_post_meta( $donation->ID, $key, true );
 }
 

--- a/includes/fields/class-charitable-donation-fields.php
+++ b/includes/fields/class-charitable-donation-fields.php
@@ -45,9 +45,9 @@ if ( ! class_exists( 'Charitable_Donation_Fields' ) ) :
          * @since 1.5.0
          *
          * @param Charitable_Fields_Registry $registry An instance of `Charitable_Field_Registry_Interface`.
-         * @param Charitable_Donation        $donation A `Charitable_Donation` instance.
+         * @param Charitable_Abstract_Donation        $donation A `Charitable_Abstract_Donation` instance.
          */
-        public function __construct( Charitable_Field_Registry_Interface $registry, Charitable_Donation $donation ) {
+        public function __construct( Charitable_Field_Registry_Interface $registry, Charitable_Abstract_Donation $donation ) {
             $this->registry = $registry;
             $this->donation = $donation;
         }


### PR DESCRIPTION
… when same metabox is passed a Charitable_Recurring_Donation. This is breaking the metaboxes for Recurring donations.