### PR TITLE
switch duplicate charitable_donation_receipt_before hook to "after"

### DIFF
--- a/templates/content-donation-receipt.php
+++ b/templates/content-donation-receipt.php
@@ -43,4 +43,4 @@ do_action( 'charitable_donation_receipt', $donation );
  *
  * @param   Charitable_Donation $donation The Donation object.
  */
-do_action( 'charitable_donation_receipt_before', $donation );
+do_action( 'charitable_donation_receipt_after', $donation );


### PR DESCRIPTION
`charitable_donation_receipt_before` appears twice. The second one should be `charitable_donation_receipt_after`