### PR TITLE
Delete the user_dashboard transient when location is not checked - fixes #52 Reach

### DIFF
--- a/includes/public/class-charitable-user-dashboard.php
+++ b/includes/public/class-charitable-user-dashboard.php
@@ -159,8 +159,9 @@ if ( ! class_exists( 'Charitable_User_Dashboard' ) ) :
 		 */
 		public function flush_menu_object_cache( $menu_id ) {
 			$nav_menu = wp_get_nav_menu_object( $this->get_nav_id() );
-
-			if ( $nav_menu && $menu_id == $nav_menu->term_id ) {
+            
+            //if $nav_menu is not set that means the location 'charitable-dashboard' is not checked
+			if ( !$nav_menu || $menu_id == $nav_menu->term_id ) {
 
 				delete_transient( 'charitable_user_dashboard_objects' );
 

--- a/includes/public/class-charitable-user-dashboard.php
+++ b/includes/public/class-charitable-user-dashboard.php
@@ -161,7 +161,7 @@ if ( ! class_exists( 'Charitable_User_Dashboard' ) ) :
 			$nav_menu = wp_get_nav_menu_object( $this->get_nav_id() );
             
             //if $nav_menu is not set that means the location 'charitable-dashboard' is not checked
-			if ( !$nav_menu || $menu_id == $nav_menu->term_id ) {
+			if ( $nav_menu == 0 || $menu_id == $nav_menu->term_id ) {
 
 				delete_transient( 'charitable_user_dashboard_objects' );
 


### PR DESCRIPTION
When the menu location charitable-dashboard isn't checked or menu is updated delete the transient. This fixes https://github.com/Charitable/Reach/issues/52