### PR TITLE
Fixed broken string containing improperly handled variable

### DIFF
--- a/includes/admin/charitable-core-admin-functions.php
+++ b/includes/admin/charitable-core-admin-functions.php
@@ -44,7 +44,11 @@ function charitable_admin_view( $view, $view_args = array() ) {
 	if ( ! is_readable( $filename ) ) {
 		charitable_get_deprecated()->doing_it_wrong(
 			__FUNCTION__,
-			__( 'Passed view (' . $filename . ') not found or is not readable.', 'charitable' ),
+			printf(
+				/* translators: %s: Filename of passed view */
+				__( 'Passed view (%s) not found or is not readable.', 'charitable' ),
+				$filename
+			),
 			'1.0.0'
 		);
 
@@ -121,7 +125,7 @@ function charitable_is_settings_view( $tab = '' ) {
  * This is based on WordPress' do_settings_fields but allows the possibility
  * of leaving out a field lable/title, for fullwidth fields.
  *
- * @see    do_settings_fields 
+ * @see    do_settings_fields
  *
  * @since  1.0.0
  *


### PR DESCRIPTION
Hello,

While translating I came across an incomplete string;
Incomplete String - https://translate.wordpress.org/projects/wp-plugins/charitable/dev/en-ca/default?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=6998794&filters%5Btranslation_id%5D=59578262

Looking at it further found that the variable use was invalid as translation functions shouldn't contain variables and instead should use printf/sprintf to inject them.
More information - https://developer.wordpress.org/themes/functionality/internationalization/#variables

*Note: This may only surface on non-en_US sites so for testing please use a translated site.