### PR TITLE
make certain processor methods public

### DIFF
--- a/includes/donations/class-charitable-donation-processor.php
+++ b/includes/donations/class-charitable-donation-processor.php
@@ -851,7 +851,7 @@ if ( ! class_exists( 'Charitable_Donation_Processor' ) ) :
 		 *
 		 * @return string
 		 */
-		protected function get_donation_status() {
+		public function get_donation_status() {
 			$status = $this->get_donation_data_value( 'status', 'charitable-pending' );
 
 			if ( ! charitable_is_valid_donation_status( $status ) ) {
@@ -868,7 +868,7 @@ if ( ! class_exists( 'Charitable_Donation_Processor' ) ) :
 		 *
 		 * @return string
 		 */
-		protected function get_donor_name() {
+		public function get_donor_name() {
 			$user       = new WP_User( $this->get_donation_data_value( 'user_id', 0 ) );
 			$user_data  = $this->get_donation_data_value( 'user' );
 			$first_name = isset( $user_data['first_name'] ) ? $user_data['first_name'] : $user->get( 'first_name' );
@@ -883,7 +883,7 @@ if ( ! class_exists( 'Charitable_Donation_Processor' ) ) :
 		 *
 		 * @return string
 		 */
-		protected function get_campaign_names() {
+		public function get_campaign_names() {
 			$campaigns = wp_list_pluck( $this->get_campaign_donations_data(), 'campaign_name' );
 			return implode( ', ', $campaigns );
 		}

--- a/includes/donations/class-charitable-donation-processor.php
+++ b/includes/donations/class-charitable-donation-processor.php
@@ -569,6 +569,9 @@ if ( ! class_exists( 'Charitable_Donation_Processor' ) ) :
 			 * @param Charitable_Donation_Processor $processor   This instance of `Charitable_Donation_Processor`.
 			 */
 			$meta = apply_filters( 'charitable_donation_meta', $meta, $donation_id, $this );
+			
+			// Save meta to donation_data.
+			$this->set_donation_data_value( 'meta', $meta );
 
 			foreach ( $meta as $meta_key => $value ) {
 				/**


### PR DESCRIPTION
With the changes to the Recurring processor behavior, I need to be able to access some methods to retrieve data from an unrelated class. This makes `get_donation_status()`, `get_donor_name()` and `get_campaign_names()` public methods. I only _need_ the donor name, but the others make sense to me.