### PR TITLE
Add a rich text editor admin field type.

### DIFF
--- a/includes/admin/views/metaboxes/field-types/editor.php
+++ b/includes/admin/views/metaboxes/field-types/editor.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Display rich text editor field.
+ *
+ * @author    Eric Daams
+ * @package   Charitable/Admin Views/Metaboxes
+ * @copyright Copyright (c) 2019, Studio 164a
+ * @since     1.7.0
+ * @version   1.7.0
+ */
+
+if ( ! array_key_exists( 'form_view', $view_args ) || ! $view_args['form_view']->field_has_required_args( $view_args ) ) {
+	return;
+}
+
+$is_required = array_key_exists( 'required', $view_args ) && $view_args['required'];
+
+?>
+<div id="<?php echo esc_attr( $view_args['wrapper_id'] ); ?>" class="<?php echo esc_attr( $view_args['wrapper_class'] ); ?>" <?php echo charitable_get_arbitrary_attributes( $view_args ); ?>>
+	<?php if ( isset( $view_args['label'] ) ) : ?>
+		<label for="<?php echo esc_attr( $view_args['id'] ); ?>">
+			<?php
+			echo esc_html( $view_args['label'] );
+			if ( $is_required ) :
+				?>
+				<abbr class="required" title="required">*</abbr>
+				<?php
+			endif;
+			?>
+		</label>
+	<?php endif ?>
+
+	<?php
+	wp_editor(
+		$view_args['value'],
+		$view_args['id'],
+		array(
+			'textarea_name' => $view_args['key'],
+			'tabindex'      => $view_args['tabindex'],
+			'editor_class'  => $is_required ? 'required' : '',
+		)
+	);
+	?>
+
+<?php if ( isset( $view_args['description'] ) ) : ?>
+		<span class="charitable-helper"><?php echo esc_html( $view_args['description'] ); ?></span>
+	<?php endif ?>
+</div><!-- #<?php echo $view_args['wrapper_id']; ?> -->


### PR DESCRIPTION
Yay #Hacktoberfest! This is a first pass and I'm not yet certain if there's a way to force `wp_editor` to be required. There's nothing for that in the default `wp_editor` args, so it would need to be some other solution. 

Test with the following:

```
/**
 * Register editor field for campaigns.
 * @param array $fields - The campaign meta fields.
 * @return array
 */
function kia_editor_field_test( $fields ) {
	$fields['test_editor'] = array(
		'label'          => __( 'A sample editor', 'my-text-domain' ),
		'data_type'      => 'meta',
		'admin_form'     => array(
			'section'     => 'campaign-donation-options',
			'type'        => 'editor',
			'description' => __( 'Test out the editor field.', 'my-text-domain' ),
			'priority'    => 1,
		),
		'email_tag'      => false,
		'show_in_export' => false,
		'value_callback' => function( Charitable_Campaign $campaign, $key ) {
			$value = $campaign->get_meta( '_campaign_test_editor' );
			return apply_filters( 'the_content', $value );
		},
	);
	return $fields;
}
add_filter( 'charitable_default_campaign_fields', 'kia_editor_field_test' );


/**
 * Display editor output on campaign.
 * @param obj $campaign - Charitable_Campaign object.
 */
function kia_display_editor_field_test( $campaign ) {
	echo $campaign->get( 'test_editor' );
}
add_action( 'charitable_campaign_summary_before', 'kia_display_editor_field_test' );
```
