### PR TITLE
set the global $post variable for endpoints if it's not set. 

### DIFF
--- a/includes/public/class-charitable-ghost-page.php
+++ b/includes/public/class-charitable-ghost-page.php
@@ -145,6 +145,10 @@ if ( ! class_exists( 'Charitable_Ghost_Page' ) ) :
 			$wp_query->is_post_type_archive = false;
 
 			$GLOBALS['wp_query'] = $wp_query;
+
+			if ( empty ( $GLOBALS['post'] ) ) {
+				$GLOBALS['post'] = $wp_query->post;
+			}
 		}
 
 		/**


### PR DESCRIPTION
closes #772 

Some sites are missing the global `$post` variable for endpoints. Which means on endpoints, `get_post()` is false and then `comments_open()` , `pings_open()` and a few other WP functions start throwing notices as they try to access properties on a `WP_Post` object, but instead of an object, it's false. 