### PR TITLE
solving Charitable_Gateway_Paypal country issue

### DIFF
--- a/includes/gateways/class-charitable-gateway-paypal.php
+++ b/includes/gateways/class-charitable-gateway-paypal.php
@@ -294,7 +294,6 @@ if ( ! class_exists( 'Charitable_Gateway_Paypal' ) ) :
 					'address1'      => isset( $user_data['address'] ) ? $user_data['address'] : '',
 					'address2'      => isset( $user_data['address_2'] ) ? $user_data['address_2'] : '',
 					'city'          => isset( $user_data['city'] ) ? $user_data['city'] : '',
-					'country'       => isset( $user_data['country'] ) ? $user_data['country'] : '',
 					'zip'           => isset( $user_data['postcode'] ) ? $user_data['postcode'] : '',
 					'invoice'       => $donation_key,
 					'amount'        => $donation->get_total_donation_amount( true ),


### PR DESCRIPTION
Update Charitable_Gateway_Paypal class to exclude country from the fields.
country field causes an issue when concatenating lang code with country code, e.g : en-PS ( en for English, PS for Palestine ).
this reflects that a js file from paypal to not load and causes 404, then stops every following scripts and then paypal donation form doesn't open.
e.g for choosing Palestine country:
https://www.paypalobjects.com/web/res/9f8/{{TOKEN}}/en-PS/_languagepack.js => 404 not found